### PR TITLE
Define an initial corpus implementation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": [ "es2015", "react" ]
+  "presets": [ "es2015", "react" ],
+  "retainLines": true
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": [ "es2015", "react" ],
-  "retainLines": true
+  "presets": [ "es2015", "react" ]
 }

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,11 @@
+instrumentation:
+  preserve-comments: true
+  excludes:
+    - "*.test.js"
+    - "__tests__/**/*"
+    - "TestUtils.js"
+  extensions:
+    - .js
+# reporting:
+#   reports:
+#     - html

--- a/doc/tinydoc.conf.js
+++ b/doc/tinydoc.conf.js
@@ -155,6 +155,11 @@ config.plugins = [
             text: 'API',
             href: '/dev/api',
           },
+
+          {
+            text: 'Corpus',
+            href: '/dev/corpus',
+          },
         ]
       },
 
@@ -167,6 +172,27 @@ config.plugins = [
   }),
 
   require('tinydoc-theme-qt')({}),
+
+  require('tinydoc-plugin-static')({
+    source: 'packages/tinydoc-corpus/README.md',
+    url: '/dev/corpus',
+    outlet: 'CJS::Landing',
+    anchorableHeadings: false
+  }),
+
+  require('tinydoc-plugin-js')({
+    routeName: 'dev/corpus',
+    corpusContext: 'Corpus',
+    useDirAsNamespace: false,
+    inferModuleIdFromFileName: true,
+
+    source: [
+      'packages/tinydoc-corpus/defs/*.js',
+      'packages/tinydoc-corpus/lib/**/*.js',
+    ],
+
+    exclude: [ /\.test\.js$/ ],
+  })
 ];
 
 [

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-react": "^3.4.1",
     "highlight.js": "^8.8.0",
     "history": "1.17.0",
-    "istanbul": "0.4.3",
+    "istanbul": "^1.0.0-alpha.2",
     "json-loader": "0.5.1",
     "karma": "^0.13.10",
     "karma-chrome-launcher": "0.1.7",

--- a/packages/tinydoc-corpus/README.md
+++ b/packages/tinydoc-corpus/README.md
@@ -1,0 +1,224 @@
+# tinydoc-corpus
+
+The corpus is tinydoc's module for indexing documents. The corpus has enough 
+semantics to ensure a correct and intuitive approach to resolving links, among
+other things like the inference of dependency and co-relation graphs between
+documents and entities.
+
+Most of tinydoc's features like link-resolving, the Spotlight, and the Preview 
+Tooltips rely on the corpus directly or indirectly - so as an upstream 
+developer, utilizing the corpus will pay off greatly.
+
+## Indexing
+
+The corpus performs a depth-first search in the AST to resolve links to 
+documents. The parameters for the search are the term, and the _context node_.
+
+A lot of care has gone into making the algorithm support an _intuitive_ 
+interface for linking to documents to make authoring a more pleasant 
+experience. The effect we're trying to achieve is that "It Just Works". This 
+is why the context node plays a great role in determining how a link is 
+resolved.
+
+### Constraints
+
+- Document identifiers MUST NOT begin with any of the following characters:
+  1. `.` (a dot)
+  2. `/` (a forward slash)
+
+### Private contextual resolving
+
+A link could be formed using a short-hand notation when it points to an 
+_entity_ within the same document (aka, a private link). The index used for
+resolving such links is kept _private_ in the sense that external documents
+will not be able to reference the entities using this notation.
+
+For example, within the context of a document `X`, linking to `#someMethod` 
+should resolve to `X#someMethod` if that entity exists, but linking to that 
+same entity from a different document, `Y`, yields nothing.
+
+### Resolving by (relative) filepath
+
+Any link that begins with `./` is expected to point to a document that can be
+found relative from the current document's filepath:
+
+    [[./path/to/file]]
+
+### Resolving by (absolute) filepath
+
+Any link that begins with `/` is expected to point to a document that can be
+found at that path, relative to the [[@assetRoot]]:
+
+    [[/path/to/file]]
+
+Let's look at an example corpus with the following contents:
+
+```
+- corpus
+|
+| - tinydoc-plugin-markdown (namespace id = MD)
+|   |
+|   |-- X (doc/X.md)
+|   |-- Y (doc/Y.md)
+|   |-- Z (doc/Z.md)
+|   
+| - tinydoc-plugin-js       (namespace id = JS)
+|   |
+|   |-- X                   (filePath = js/lib/X.js)
+|   |-- Core.X              (filePath = js/lib/core/X.js)
+|   |   |-- @id
+|   |   |-- #add
+|   |-- Core.Y              (filePath = js/lib/core/Y.js)
+|   |   |-- @id
+|   |-- Z                   (filePath = js/lib/Z.js)
+```
+
+The following table shows the resolving behavior:
+
+Context Node     | Link         | Resolved Node
+---------------- | ------------ | -----------------
+JS/Core.X@id     | X            | JS/Core.X
+JS/Core.X@id     | JS/X         | JS/X
+JS/Core.X@id     | MD/X         | MD/X
+JS/Core.X#add    | @id          | JS/Core.X@id
+JS/Core.X#add    | Y@id         | JS/Core.Y@id
+JS/Core.X#add    | Core.Y@id    | JS/Core.Y@id
+JS/Core.X#add    | JS/Core.Y@id | JS/Core.Y@id
+JS/Core.Y        | X            | JS/Core.X
+JS/Core.Y        | #add         | ! (unknown)
+JS/Core.Y        | X#add        | JS/Core.X#add
+JS/Core.Y        | X.js         | ! (ambiguous)
+JS/Core.Y        | ./X.js       | JS/Core.X
+JS/Core.Y        | ../X.js      | JS/X
+JS/Z             | X            | JS/X
+MD/X             | X            | MD/X
+MD/X             | Core.X       | JS/Core.X
+MD/Y             | X            | MD/X
+
+## The AST
+
+At the root of the corpus, we have a singleton node of type `Corpus` that
+houses a set of `Namespace` nodes. Each plugin that registers with the corpus
+has to define its own unique `Namespace` node and nest its documents underneath
+it.
+
+A `Namespace` node is the direct owner of a plugin's `Document` nodes. However,
+from that point down, the hierarchy is flexible in that a `Document` node may
+contain either `Document` nodes as children (namespacing at the plugin level)
+or leaf `DocumentEntity` nodes.
+
+This architecture is flexible enough to support a wide array of documentation 
+schemes; most kinds of textual documentation, public API references, library 
+documentation, etc., can be structured within this model.
+
+```javascript
+def("Corpus", {
+  fields: {
+    namespaces: array("Namespace")
+  }
+});
+
+def("Namespace", {
+  fields: {
+    id: String,
+    symbol: or(String, null), // defaults to "/"
+    corpusContext: or(String, null),
+    documents: or(array("Document"), null),
+    parentNode: "Corpus"
+  }
+});
+
+def("Node", {
+  fields: {
+    id: String,
+    href: or(String, null),
+    title: or(String, null),
+    summary: or(String, null),
+    filePath: or(String, null),
+    properties: or(array("Property"), null)
+  }
+});
+
+def("Document", {
+  base: "Node",
+  fields: {
+    symbol: or(String, null),
+    parentNode: or("Namespace", "Document"),
+    documents: or(array("Document"), null),
+    entities: or(array("DocumentEntity"), null),
+  }
+});
+
+def("DocumentEntity", { // terminal
+  base: "Node",
+  fields: {
+    parentNode: "Document"
+  }
+});
+
+def("Property", {
+  build: [ 'key', 'value' ],
+  fields: {
+    key: String,
+    value: or(String, Number, Boolean, RegExp, Array, Object, null)
+  }
+});
+```
+
+A sample AST for the example above:
+
+```javascript
+// JS/Core.X@id -> [[X]] -> JS/Core.X
+// JS/Core.X@id -> [[@id]] -> JS/Core@id
+// JS/Core.X@id -> [[#add]] -> JS/Core#add
+
+{ // DocumentEntity
+  type: "DocumentEntity",
+  id: "@id",
+  uid: "JS/Core.X@id",
+  indices: { "@id": 1, "X@id": 2, "Core.X@id": 3 },
+  parentNode: { // Document
+    type: "Document",
+    id: "X",
+    uid: "JS/Core.X",
+    indices: [ "X", "Core.X" ],
+    entities: [
+      ...
+    ],
+    parentNode: { // Document
+      type: "Document",
+      id: "Core",
+      uid: "JS/Core",
+      symbol: ".",
+      entities: [
+        ...
+      ],
+      documents: [
+        ...
+      ],
+      properties: [
+        {
+          key: "namespace",
+          value: true
+        }
+      ],
+      parentNode: { // Namespace
+        type: "Namespace",
+        id: "JS",
+        uid: "JS",
+        symbol: "/",
+        corpusContext: "JavaScript Modules",
+        documents: [
+          ...
+        ],
+        parentNode: { // Corpus
+          type: "Corpus",
+          namespaces: [
+            ...
+          ]
+        }
+      }
+    }
+  }
+};
+```

--- a/packages/tinydoc-corpus/defs/core.js
+++ b/packages/tinydoc-corpus/defs/core.js
@@ -1,0 +1,76 @@
+var CorpusTypes = require('../lib/CorpusTypes');
+var def = CorpusTypes.def;
+var or = CorpusTypes.or;
+var array = CorpusTypes.array;
+
+/**
+ * @module T.Corpus
+ */
+def("Corpus", {
+  fields: {
+    namespaces: array("Namespace")
+  }
+});
+
+/**
+ * @module T.Namespace
+ */
+def("Namespace", {
+  fields: {
+    id: String,
+    symbol: or(String, null), // defaults to "/"
+    corpusContext: or(String, null),
+    documents: or(array("Document"), null),
+    parentNode: "Corpus"
+  }
+});
+
+/**
+ * @module T.Node
+ */
+def("Node", {
+  fields: {
+    id: String,
+    href: or(String, null),
+    title: or(String, null),
+    summary: or(String, null),
+    filePath: or(String, null),
+    properties: or(array("Property"), null)
+  }
+});
+
+/**
+ * @module T.Document
+ * @mixes T.Node
+ */
+def("Document", {
+  base: "Node",
+  fields: {
+    symbol: or(String, null),
+    parentNode: or("Namespace", "Document"),
+    documents: or(array("Document"), null),
+    entities: or(array("DocumentEntity"), null),
+  }
+});
+
+/**
+ * @module T.Document
+ * @mixes T.Node
+ */
+def("DocumentEntity", { // terminal
+  base: "Node",
+  fields: {
+    parentNode: "Document"
+  }
+});
+
+/**
+ * @module T.Property
+ */
+def("Property", {
+  build: [ 'key', 'value' ],
+  fields: {
+    key: String,
+    value: or(String, Number, Boolean, RegExp, Array, Object, null)
+  }
+});

--- a/packages/tinydoc-corpus/index.js
+++ b/packages/tinydoc-corpus/index.js
@@ -1,0 +1,8 @@
+require('./defs/core');
+
+var Corpus = require('./lib/Corpus');
+var CorpusTypes = require('./lib/CorpusTypes');
+
+CorpusTypes.finalize();
+
+module.exports = Corpus;

--- a/packages/tinydoc-corpus/lib/Corpus.js
+++ b/packages/tinydoc-corpus/lib/Corpus.js
@@ -1,0 +1,132 @@
+var resolveLink = require('./CorpusResolver');
+var buildIndices = require('./CorpusIndexer');
+var b = require('./CorpusTypes').builders;
+var assert = require('assert');
+
+/**
+ * The Corpus public API.
+ */
+function Corpus() {
+  var exports = {};
+  var nodes = {};
+  var corpusNode = b.corpus({
+    namespaces: []
+  });
+
+  /**
+   * Retrieve a document AST node by its UID.
+   *
+   * @param {String} uid
+   *
+   * @return {T.Namespace|T.Node}
+   *         The document AST node, if found.
+   */
+  exports.get = function(uid) {
+    return nodes[uid];
+  };
+
+  /**
+   * Resolve a link to a document.
+   *
+   * @param {Object} anchor
+   * @param {T.Node} anchor.contextNode
+   *        The UID of the contextNode we're resolving from.
+   *
+   * @param {String} anchor.text
+   *        The term to use for looking up the document.
+   *
+   * @return {T.Node}
+   */
+  exports.resolve = function(anchor) {
+    if (anchor.text in nodes) {
+      return nodes[anchor.text];
+    }
+
+    return resolveLink(anchor);
+  };
+
+  /**
+   * @private
+   */
+  exports.dumpPaths = function() {
+    return Object.keys(nodes);
+  };
+
+  exports.add = add;
+
+  /**
+   * @lends Corpus
+   *
+   * Add a namespace or a document to the corpus. The corpus will be populated
+   * with all offspring nodes (if applicable).
+   *
+   * Items added to the corpus will gain a UID and will be indexed.
+   *
+   * @example
+   *
+   *     corpus.add(b.namespace({
+   *       id: 'JS',
+   *       documents: [
+   *         b.document({
+   *           id: 'jQuery'
+   *         })
+   *       ]
+   *     }))
+   *
+   * @param {T.Namespace|T.Node} node
+   */
+  function add(node) {
+    if (node.type === 'Namespace') {
+      assert(corpusNode.namespaces.map(function(x) { return x.id; }).indexOf(node.id) === -1,
+        "IntegrityViolation: a namespace with the id '" + node.id + "' already exists."
+      );
+
+      corpusNode.namespaces.push(node);
+
+      node.parentNode = corpusNode;
+      node.symbol = node.symbol || '/';
+    }
+    else {
+      assert(node.parentNode,
+        "IntegrityViolation: expected node to reference a parentNode."
+      );
+    }
+
+    node.uid = UID(node);
+    node.indices = buildIndices(node);
+
+    nodes[node.uid] = node;
+
+    if (node.documents) { // Namespace | Document
+      node.documents.forEach(add);
+    }
+
+    if (node.entities) { // Document
+      node.entities.forEach(add);
+    }
+  }
+
+  return exports;
+};
+
+function UID(sourceNode) {
+  var fragments = [];
+  var node = sourceNode;
+
+  do {
+    if (sourceNode !== node) {
+      if (node.symbol) {
+        fragments.unshift(node.symbol);
+      }
+    }
+
+    if (node.id) {
+      fragments.unshift(node.id);
+    }
+  } while ((node = node.parentNode));
+
+  return fragments.join('');
+}
+
+module.exports = Corpus;
+

--- a/packages/tinydoc-corpus/lib/CorpusIndexer.js
+++ b/packages/tinydoc-corpus/lib/CorpusIndexer.js
@@ -1,0 +1,30 @@
+module.exports = function buildIndices(node) {
+  if (node.type === 'Namespace') {
+    return {};
+  }
+
+  var indices = {};
+  var ancestors = [];
+  var anchorNode = node;
+
+  do {
+    if (anchorNode.type === 'Namespace') {
+      break;
+    }
+
+    ancestors.unshift(anchorNode);
+
+    indices[ancestors.map(identifyNode).join('')] = ancestors.length;
+  } while ((anchorNode = anchorNode.parentNode));
+
+  return indices;
+
+  function identifyNode(x, i) {
+    if (i > 0) {
+      return (ancestors[i-1].symbol || '') + x.id;
+    }
+    else {
+      return x.id;
+    }
+  }
+}

--- a/packages/tinydoc-corpus/lib/CorpusResolver.js
+++ b/packages/tinydoc-corpus/lib/CorpusResolver.js
@@ -1,0 +1,109 @@
+module.exports = function resolve(anchor, options, _visited) {
+  var targetNode;
+  var term = anchor.text;
+  var contextNode = anchor.contextNode;
+  var parentNode = contextNode.parentNode;
+  var visited = _visited || {};
+  var trace = options && options.trace ? console.log.bind(console) : Function.prototype;
+
+  trace("Context:", contextNode.uid);
+  trace("Term:", term);
+
+  // descend first
+  if (!isLeaf(contextNode)) {
+    targetNode = searchInBranch(contextNode);
+  }
+
+  // go up the tree one level, unless we're at the Corpus level
+  if (!targetNode && parentNode) {
+    trace("Found nothing at this level, looking for a document in my ancestor...");
+    trace(Array(80).join('-'))
+
+    return resolve({ contextNode: parentNode, text: term }, options, visited);
+  }
+
+  function searchInBranch(node) {
+    var result;
+    trace("Searching '%s'...", node.uid)
+
+    if (hasVisited(node)) {
+      trace("- Skipping '%s' - already seen before!", node.uid);
+      return;
+    }
+
+    if (node.entities) { // Document
+      node.entities.some(visitLeafNode);
+    }
+
+    if (!result && node.documents) { // Namespace | Document
+      node.documents.some(visitBranchNode);
+    }
+
+    if (!result && node.namespaces) { // Corpus
+      node.namespaces.some(visitBranchNode);
+    }
+
+    function visitBranchNode(childNode) {
+      if (hasVisited(childNode)) {
+        trace("- Skipping '%s' - already seen before!", childNode.uid);
+        return;
+      }
+
+      trace("- Checking '%s'", childNode.uid);
+
+      if (matches(childNode)) {
+        result = childNode;
+      }
+      else {
+        result = searchInBranch(childNode);
+      }
+
+      markVisited(childNode);
+
+      return !!result;
+    }
+
+    function visitLeafNode(childNode) {
+      if (hasVisited(childNode)) {
+        trace("- Skipping '%s' - already seen before!", childNode.uid);
+        return;
+      }
+
+      trace("- Checking entity '%s'...", childNode.uid);
+
+      markVisited(childNode);
+
+      if (matches(childNode, childNode.parentNode !== contextNode)) {
+        result = childNode;
+      }
+
+      return !!result;
+    }
+
+    return result;
+  }
+
+  function matches(node, dontLookForPrivateIndices) {
+    if (dontLookForPrivateIndices) {
+      return node.uid === term || node.indices[term] > 1;
+    }
+    else {
+      return node.uid === term || term in node.indices;
+    }
+  }
+
+  function markVisited(node) {
+    visited[node.uid] = true;
+  }
+
+  function hasVisited(node) {
+    return node.uid in visited;
+  }
+
+  return targetNode;
+};
+
+function isLeaf(node) {
+  return node.type === 'DocumentEntity';
+}
+

--- a/packages/tinydoc-corpus/lib/CorpusTypes.js
+++ b/packages/tinydoc-corpus/lib/CorpusTypes.js
@@ -1,0 +1,270 @@
+var assert = require('assert');
+var typeDefs = {};
+var typeCheckers = {};
+var builders = {};
+var assign = require('lodash').assign;
+var uniq = require('lodash').uniq;
+var camelizeCache = {};
+var definitions = [];
+
+function def(typeName, typeDef) {
+  typeDefs[typeName] = typeDef;
+
+  definitions.push(function() {
+    if (typeDef.base) {
+      assign(typeDef.fields, typeDefs[typeDef.base].fields);
+    }
+
+    typeCheckers[typeName] = Object.keys(typeDef.fields).reduce(function(map, field) {
+      map[field] = createTypeChecker(typeDef.fields[field]);
+      return map;
+    }, {});
+
+    builders[camelize(typeName)] = createTypeBuilder(typeName, typeDef);
+  });
+};
+
+function createTypeBuilder(typeName, typeDef) {
+  var TypeBuilder, constructor; // eslint-disable-line
+  var knownFields = Object.keys(typeDef.fields);
+  var requiredFields = knownFields.filter(function(field) {
+    return !typeDef.fields[field].optional;
+  });
+
+  // a hack so that constructor.name displays the type name properly
+  eval( // eslint-disable-line
+    'TypeBuilder = function ' + typeName + '() {' +
+    '  return constructor.apply(this, arguments);' +
+    '};'
+  );
+
+  constructor = function(fields) {
+    if (!(this instanceof TypeBuilder)) {
+      return new TypeBuilder(fields || {});
+    }
+
+    // verify all required fields are present
+    requiredFields.forEach(function(field) {
+      if (field === 'parentNode') { return; }
+
+      assert(field in fields,
+        "Field '" + field + "' is missing for a node of type '" + typeName + "'."
+      );
+    });
+
+    this.consumeFields(fields);
+    this.type = typeName;
+
+    return this;
+  };
+
+  TypeBuilder.__typeDef__ = typeDef;
+  TypeBuilder.prototype.toJSON = function() {
+    return knownFields.concat(['type']).reduce(function(map, field) {
+      map[field] = this[field];
+
+      return map;
+    }.bind(this), {});
+  };
+
+  TypeBuilder.prototype.consumeFields = function(fields) {
+    var that = this;
+
+    // reject unrecognized fields and validate recognized ones
+    Object.keys(fields).forEach(function(field) {
+      var typeError;
+
+      assert(field in typeDef.fields,
+        "Field '" + field + "' is unrecognized for a node of type '" + typeName + "'."
+      );
+
+      typeError = typeCheckers[typeName][field](fields[field]);
+
+      if (typeError) {
+        assert(false, "TypeError: " + typeError + " (source: " + typeName + "[\"" + field + "\"])");
+      }
+
+      if (Array.isArray(fields[field])) {
+        fields[field].forEach(assignParentNode);
+      }
+      else {
+        assignParentNode(fields[field]);
+      }
+
+      that[field] = fields[field];
+    });
+
+    function assignParentNode(x) {
+      if (x) { // guard against nil values
+        var xCtor = x.constructor;
+
+        if (xCtor.__typeDef__ && 'parentNode' in xCtor.__typeDef__.fields) {
+          x.parentNode = that;
+        }
+      }
+    }
+  };
+
+  return TypeBuilder;
+}
+
+function createTypeChecker(type) {
+  return function(x) {
+    if (type === null) {
+      if (x !== null && x !== undefined) {
+        return 'Expected value to be "null"';
+      }
+    }
+    else if (isOrType(type)) {
+      if (!checkUnionType(type, x)) {
+        return (
+          'Expected value to be of one of the types [ ' +
+          type.typeNames + ' ], not \'' + getTypeOf(x) + '\''
+        );
+      }
+    }
+    else if (isArrayType(type)) {
+      return checkArrayType(type, x);
+    }
+    else if (typeof type === 'string') {
+      return checkCustomType(type, x);
+    }
+    else {
+      return checkPrimitiveType(type, x);
+    }
+  };
+}
+
+function checkPrimitiveType(type, x) {
+  var expectedType = type.name;
+
+  if (!x || x.constructor !== type) {
+    return "Expected a value of type '" + expectedType + "', not '" + getTypeOf(x) + "'."
+  }
+}
+
+function checkUnionType(type, x) {
+  return type.types.some(function(typeChecker) {
+    if (!typeChecker(x)) {
+      return true;
+    }
+  });
+}
+
+function checkCustomType(type, x) {
+  var typeConstructor = builders[camelize(type)];
+  var expectedType = typeConstructor.name;
+
+  if (!x || x.constructor !== typeConstructor) {
+    return "Expected a value of type '" + expectedType + "', not '" + (getTypeOf(x)) + "'."
+  }
+}
+
+function checkArrayType(type, x) {
+  var error;
+
+  if (!Array.isArray(x)) {
+    return (
+      'Expected value to be an array of the types [ ' +
+      type.typeNames + ' ], not \'' + getTypeOf(x) + '\''
+    );
+  }
+
+  x.some(function(y, index) {
+    if (!checkUnionType(type, y)) {
+      error = (
+        'Expected value at [' + index + '] to be of one of the types [ ' +
+        type.typeNames + ' ], not \'' + getTypeOf(y) + '\''
+      );
+
+      return true;
+    }
+  });
+
+  return error;
+}
+
+function camelize(str, lowerFirst) {
+  if (camelizeCache[str]) {
+    return camelizeCache[str];
+  }
+
+  camelizeCache[str] = (str || '').replace(/(?:^|[-_])(\w)/g, function(_, c, index) {
+    if (index === 0 && lowerFirst !== false) {
+      return c ? c.toLowerCase() : '';
+    } else {
+      return c ? c.toUpperCase() : '';
+    }
+  });
+
+  return camelizeCache[str];
+};
+
+function array() {
+  var valueTypes = [].slice.call(arguments);
+
+  return {
+    type: 'array',
+    types: valueTypes.map(createTypeChecker),
+    typeNames: 'Array.<' + valueTypes.map(getTypeName).join(' | ') + '>',
+  };
+}
+
+function isArrayType(type) {
+  return type && type.type === 'array';
+}
+
+function or() {
+  var valueTypes = [].slice.call(arguments);
+
+  return {
+    type: 'or',
+    types: valueTypes.map(createTypeChecker),
+    typeNames: valueTypes.map(getTypeName).join(' | '),
+    optional: valueTypes.some(function(x) { return x === null }),
+  };
+}
+
+function isOrType(type) {
+  return type && type.type === 'or';
+}
+
+function finalize() {
+  definitions.forEach(function(fn) {
+    fn();
+  });
+
+  definitions.splice(0);
+}
+
+function getTypeName(x) {
+  if (typeof x === 'string') {
+    return x;
+  }
+  else if (typeof x === 'function') {
+    return x.name;
+  }
+  else if (x === null) {
+    return 'null';
+  }
+  else if (isArrayType(x)) {
+    return x.typeNames;
+  }
+  else {
+    console.log('unknown type!', typeof x, x)
+    return String(x);
+  }
+}
+
+function getTypeOf(x) {
+  if (Array.isArray(x)) {
+    return 'Array.<' + uniq(x.map(getTypeOf)).join(', ') + '>';
+  }
+  return (x && x.constructor) ? x.constructor.name : typeof x;
+}
+
+exports.builders = builders;
+exports.def = def;
+exports.array = array;
+exports.or = or;
+exports.finalize = finalize;

--- a/packages/tinydoc-corpus/lib/__tests__/Corpus.test.js
+++ b/packages/tinydoc-corpus/lib/__tests__/Corpus.test.js
@@ -1,11 +1,11 @@
 require('../../');
 
-const Subject = require("../Corpus");
-const { builders: b } = require('../CorpusTypes');
-const { assert } = require('chai');
+var Subject = require("../Corpus");
+var b = require('../CorpusTypes').builders;
+var assert = require('chai').assert;
 
 describe('Corpus', function() {
-  let subject;
+  var subject;
 
   beforeEach(function() {
     subject = Subject();
@@ -15,7 +15,7 @@ describe('Corpus', function() {
   });
 
   it('lets me add a namespace', function() {
-    const ns = b.namespace({
+    var ns = b.namespace({
       id: 'JS',
       corpusContext: 'JavaScripts',
       documents: []
@@ -27,7 +27,7 @@ describe('Corpus', function() {
   });
 
   it('tracks documents within a namespace', function() {
-    const ns = b.namespace({
+    var ns = b.namespace({
       id: 'JS',
       corpusContext: 'JavaScripts',
       documents: [
@@ -45,7 +45,7 @@ describe('Corpus', function() {
   });
 
   it('allows me to customize the namespace symbol', function() {
-    const ns = b.namespace({
+    var ns = b.namespace({
       id: 'API',
       symbol: '::',
       corpusContext: 'Rails API',
@@ -155,7 +155,7 @@ describe('Corpus', function() {
       );
     });
 
-    const specs = [
+    [
       { ctx: "JS/Core.X@name"     , link: "X"               , res: "JS/Core.X" },
       { ctx: "JS/Core.X@name"     , link: "JS/X"            , res: "JS/X" },
       { ctx: "JS/Core.X@name"     , link: "MD/X"            , res: "MD/X" },
@@ -175,8 +175,9 @@ describe('Corpus', function() {
       { ctx: "MD/Y"             , link: "X"            , res: "MD/X" },
     ].forEach(function(spec) {
       var fn = spec.only ? it.only : it;
-      fn(`resolves '${spec.res}' from '${spec.ctx}' using '${spec.link}'`, function() {
-        const document = subject.resolve({
+
+      fn("resolves '" + spec.res + "' from '" + spec.ctx + "' using '" + spec.link + "'", function() {
+        var document = subject.resolve({
           text: spec.link,
           contextNode: subject.get(spec.ctx)
         });

--- a/packages/tinydoc-corpus/lib/__tests__/Corpus.test.js
+++ b/packages/tinydoc-corpus/lib/__tests__/Corpus.test.js
@@ -1,0 +1,210 @@
+require('../../');
+
+const Subject = require("../Corpus");
+const { builders: b } = require('../CorpusTypes');
+const { assert } = require('chai');
+
+describe('Corpus', function() {
+  let subject;
+
+  beforeEach(function() {
+    subject = Subject();
+  });
+
+  it('works', function() {
+  });
+
+  it('lets me add a namespace', function() {
+    const ns = b.namespace({
+      id: 'JS',
+      corpusContext: 'JavaScripts',
+      documents: []
+    });
+
+    subject.add(ns);
+
+    assert.equal(subject.get('JS'), ns);
+  });
+
+  it('tracks documents within a namespace', function() {
+    const ns = b.namespace({
+      id: 'JS',
+      corpusContext: 'JavaScripts',
+      documents: [
+        b.document({
+          id: 'Cache',
+          entities: [],
+        })
+      ]
+    });
+
+    subject.add(ns);
+
+    assert.equal(subject.get('JS'), ns);
+    assert.equal(subject.get('JS/Cache'), ns.documents[0]);
+  });
+
+  it('allows me to customize the namespace symbol', function() {
+    const ns = b.namespace({
+      id: 'API',
+      symbol: '::',
+      corpusContext: 'Rails API',
+      documents: [
+        b.document({
+          id: 'Users'
+        })
+      ]
+    });
+
+    subject.add(ns);
+
+    assert.equal(subject.get('API'), ns);
+    assert.equal(subject.get('API::Users'), ns.documents[0]);
+  });
+
+  it('borks if the namespace id is taken', function() {
+    subject.add(b.namespace({ id: 'foo' }));
+
+    assert.throws(function() {
+      subject.add(b.namespace({ id: 'foo' }));
+    }, "IntegrityViolation: a namespace with the id 'foo' already exists.");
+  });
+
+  it('borks if i try to add a non-namespace node without a parentNode', function() {
+    assert.throws(function() {
+      subject.add(b.document({ id: 'foo' }));
+    }, "IntegrityViolation: expected node to reference a parentNode.");
+  });
+
+  describe('resolving', function() {
+    beforeEach(function() {
+      subject.add(
+        b.namespace({
+          id: 'MD',
+          corpusContext: 'Articles',
+          documents: [
+            b.document({
+              id: 'X',
+              filePath: '/doc/articles/X.md',
+              entities: [],
+            }),
+
+            b.document({
+              id: 'Y',
+              filePath: '/doc/articles/Y.md',
+              entities: [],
+            }),
+
+            b.document({
+              id: 'Z',
+              filePath: '/doc/articles/Z.md',
+              entities: [],
+            }),
+          ]
+        })
+      );
+
+      subject.add(
+        b.namespace({
+          id: 'JS',
+          corpusContext: 'JavaScripts',
+          documents: [
+            b.document({
+              id: 'X',
+              filePath: '/js/lib/X.js',
+              entities: [],
+            }),
+
+            b.document({
+              id: 'Z',
+              filePath: '/js/lib/Z.js',
+            }),
+
+            b.document({
+              id: 'Core',
+              symbol: '.',
+
+              documents: [
+                b.document({
+                  id: 'X',
+                  filePath: '/js/lib/core/X.js',
+                  entities: [
+                    b.documentEntity({
+                      id: '@name'
+                    }),
+
+                    b.documentEntity({
+                      id: '#add'
+                    })
+                  ]
+                }),
+
+                b.document({
+                  id: 'Y',
+                  filePath: '/js/lib/core/Y.js',
+                  entities: [
+                    b.documentEntity({
+                      id: '@name'
+                    })
+                  ]
+                }),
+              ]
+            })
+          ]
+        })
+      );
+    });
+
+    const specs = [
+      { ctx: "JS/Core.X@name"     , link: "X"               , res: "JS/Core.X" },
+      { ctx: "JS/Core.X@name"     , link: "JS/X"            , res: "JS/X" },
+      { ctx: "JS/Core.X@name"     , link: "MD/X"            , res: "MD/X" },
+      { ctx: "JS/Core.X#add"      , link: "@name"           , res: "JS/Core.X@name" },
+      { ctx: "JS/Core.X#add"      , link: "Y@name"          , res: "JS/Core.Y@name" },
+      { ctx: "JS/Core.X#add"      , link: "Core.Y@name"     , res: "JS/Core.Y@name" },
+      { ctx: "JS/Core.X#add"      , link: "JS/Core.Y@name"  , res: "JS/Core.Y@name" },
+      { ctx: "JS/Core.Y"        , link: "X"            , res: "JS/Core.X" },
+      { ctx: "JS/Core.Y"        , link: "#add"         , res: null },
+      { ctx: "JS/Core.Y"        , link: "X#add"        , res: "JS/Core.X#add" },
+      // { ctx: "JS/Core.Y"        , link: "X.js"         , res: null },
+      // { ctx: "JS/Core.Y"        , link: "./X.js"       , res: "JS/Core.X" },
+      // { ctx: "JS/Core.Y"        , link: "../X.js"      , res: "JS/X" },
+      { ctx: "JS/Z"             , link: "X"            , res: "JS/X" },
+      { ctx: "MD/X"             , link: "X"            , res: "MD/X" },
+      { ctx: "MD/X"             , link: "Core.X"       , res: "JS/Core.X" },
+      { ctx: "MD/Y"             , link: "X"            , res: "MD/X" },
+    ].forEach(function(spec) {
+      var fn = spec.only ? it.only : it;
+      fn(`resolves '${spec.res}' from '${spec.ctx}' using '${spec.link}'`, function() {
+        const document = subject.resolve({
+          text: spec.link,
+          contextNode: subject.get(spec.ctx)
+        });
+
+        if (spec.res === null) {
+          if (document) {
+            subject.resolve({
+              text: spec.link,
+              contextNode: subject.get(spec.ctx),
+            }, { trace: true });
+          }
+
+          assert.notOk(document);
+        }
+        else {
+          if (!document) {
+            subject.resolve({
+              text: spec.link,
+              contextNode: subject.get(spec.ctx),
+            }, { trace: true });
+          }
+
+          assert.ok(document);
+          assert.equal(document, subject.get(spec.res),
+            document.id + " vs " + spec.res
+          );
+        }
+      })
+    })
+  })
+});

--- a/packages/tinydoc-corpus/lib/__tests__/CorpusTypes.test.js
+++ b/packages/tinydoc-corpus/lib/__tests__/CorpusTypes.test.js
@@ -1,0 +1,130 @@
+require('../../');
+
+const assert = require('chai').assert;
+const Subject = require("../CorpusTypes");
+const b = Subject.builders;
+
+describe("CorpusTypes", function() {
+
+  describe('type checkers', function() {
+    it('works with primitive types [String]', function() {
+      b.property({
+        key: 'foo',
+        value: 'bar'
+      });
+
+      assert.throws(function() {
+        b.property({
+          key: 5,
+          value: 'bar'
+        });
+      }, "TypeError: Expected a value of type 'String', not 'Number'");
+    });
+
+    it('works with custom types [Property]', function() {
+      Subject.def("Foo", {
+        fields: {
+          id: "Property"
+        }
+      });
+
+      Subject.finalize();
+
+      assert.throws(function() {
+        b.foo({
+          id: '5'
+        });
+      }, "TypeError: Expected a value of type 'Property', not 'String'");
+    });
+
+    it('works with an array of types [array(...)]', function() {
+      Subject.def("Foo", {
+        fields: {
+          id: Subject.array("Property", String, null)
+        }
+      });
+
+      Subject.finalize();
+
+      b.foo({ id: [ b.property({ key: 'foo', value: 'bar' }) ] });
+      b.foo({ id: [ '5' ] });
+      b.foo({ id: [ null ] });
+
+      assert.throws(function() {
+        b.foo({ id: [ 5 ] });
+      }, /TypeError: Expected value at \[0\] to be of one of the types.*not 'Number'/);
+    });
+
+    it('works with union types [or(...)]', function() {
+      Subject.def("Foo", {
+        fields: {
+          id: Subject.or(String, Number, null)
+        }
+      });
+
+      Subject.finalize();
+
+      b.foo({ id: 5 });
+      b.foo({ id: '5' });
+      b.foo({ id: null });
+
+      assert.throws(function() {
+        b.foo({ id: [ 5 ] });
+      }, /TypeError: Expected value to be of one of the types.*not 'Array.<Number>'/);
+    });
+  });
+
+  it('works', function() {
+    benchmark({ times: 1 }, function() {
+      b.document({
+        id: 'd1',
+        entities:
+        [
+          b.documentEntity({
+            id: 'd1#a',
+          }),
+        ],
+        documents: [
+          b.document({
+            id: 'd2',
+            entities: [
+              b.documentEntity({
+                id: 'd2#a',
+              })
+            ]
+          })
+        ]
+      });
+    });
+  });
+
+  describe('builders', function() {
+    it.skip('should work with non-object parameters for types that support it', function() {
+      assert.equal(b.literal('foo').value, 'foo');
+      assert.equal(b.property(b.literal('foo'), 'bar').key.value, 'foo');
+      assert.equal(b.property(b.literal('foo'), 'bar').value, 'bar');
+    });
+  });
+});
+
+function benchmark(options, fn) {
+  const startTime = new Date();
+  var i;
+
+  if (options.log !== false) {
+    console.log('Benchmark: applying %d iterations...', options.times);
+  }
+
+  for (i = 0; i < options.times; ++i) {
+    fn();
+  }
+
+  const endTime = new Date();
+  const delta = endTime - startTime;
+
+  if (options.log !== false) {
+    console.log('Benchmark: %d iterations complete in %d ms', options.times, delta);
+  }
+
+  return delta;
+}

--- a/packages/tinydoc-corpus/lib/__tests__/CorpusTypes.test.js
+++ b/packages/tinydoc-corpus/lib/__tests__/CorpusTypes.test.js
@@ -1,8 +1,8 @@
 require('../../');
 
-const assert = require('chai').assert;
-const Subject = require("../CorpusTypes");
-const b = Subject.builders;
+var assert = require('chai').assert;
+var Subject = require("../CorpusTypes");
+var b = Subject.builders;
 
 describe("CorpusTypes", function() {
 
@@ -108,7 +108,7 @@ describe("CorpusTypes", function() {
 });
 
 function benchmark(options, fn) {
-  const startTime = new Date();
+  var startTime = new Date();
   var i;
 
   if (options.log !== false) {
@@ -119,8 +119,8 @@ function benchmark(options, fn) {
     fn();
   }
 
-  const endTime = new Date();
-  const delta = endTime - startTime;
+  var endTime = new Date();
+  var delta = endTime - startTime;
 
   if (options.log !== false) {
     console.log('Benchmark: %d iterations complete in %d ms', options.times, delta);

--- a/packages/tinydoc-corpus/package.json
+++ b/packages/tinydoc-corpus/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "tinydoc-corpus",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "Ahmad Amireh",
+  "license": "MIT"
+}

--- a/packages/tinydoc-plugin-js/ui/shared/components/Doc.js
+++ b/packages/tinydoc-plugin-js/ui/shared/components/Doc.js
@@ -75,6 +75,7 @@ var Doc = React.createClass({
           <h4
             className="doc-entity__header collapsible-header anchorable-heading"
             onClick={this.toggleCollapsed}
+            title={doc.name}
           >
             {this.renderCollapser()}
 

--- a/packages/tinydoc-theme-qt/ui/index.less
+++ b/packages/tinydoc-theme-qt/ui/index.less
@@ -90,6 +90,15 @@ h4, h5, h6 {
 
 .schemable({
   .doc-entity {
+    &__name {
+      max-width: 100%;
+      overflow: hidden;
+      display: block;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      margin-right: 1em;
+    }
+
     &:not(:last-of-type) {
       border-bottom: none;
     }


### PR DESCRIPTION
The corpus in this patch can:

- accept namespace, document, and document entity nodes
- index the nodes
- resolve links to those nodes

Closes #47 